### PR TITLE
ensure all tasks are done in configureDatabase before returning

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,7 @@ export async function configureDatabase<T extends CouchDoc>(databaseUrl: string,
     }
 
     if (Array.isArray(configuration.designDocs) && configuration.designDocs.length > 0) {
-        configuration.designDocs.forEach(async designDoc => {
+        await Promise.all(configuration.designDocs.map(async designDoc => {
             const url = `${databaseUrl}/${configuration.name}/_design/${designDoc.name}`;
             const getDoc = await Axios.get(url);
             const okay = isOkay(getDoc);
@@ -83,7 +83,6 @@ export async function configureDatabase<T extends CouchDoc>(databaseUrl: string,
 
             if (!isOkay && getDoc.status !== 404) {
                 inspect(`Davenport: Failed to retrieve design doc "${designDoc.name}". ${getDoc.status} ${getDoc.statusText}`, getDoc.data);
-
                 return;
             }
 
@@ -126,8 +125,10 @@ export async function configureDatabase<T extends CouchDoc>(databaseUrl: string,
                     inspect(`Davenport: Could not create or update CouchDB design doc "${designDoc.name}". ${result.status} ${result.statusText}`, result.data);
                 }
             }
-        })
-    };
+
+            return Promise.resolve();
+        }));
+    }
 
     return new Client<T>(databaseUrl, configuration.name, options);
 }


### PR DESCRIPTION
After using configureDatabase I wanted to seed the db, so I was going to check if certain documents existed in the database and create them if they didn't. During testing I found it blew up because couchdb returned a 404 when I tried to query my view. But after looking at the database I found the view did exist. It took some debugging to determine that it was a race condition because configureDatabase was returning before actually creating the design doc.

Using "configuration.designDocs.forEach" creates an async task for each designDoc but does not actually wait for it to complete before continuing.
