### PR TITLE
Add methods to create and delete a database.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -402,6 +402,22 @@ export class Client<T extends CouchDoc> {
         return body;
     }
 
+    /**
+     * Creates the database associated with this client
+     */
+    public async createDb(url: string = this.databaseUrl): Promise<BasicCouchResponse> {
+        const result = await this.axios.put(url);
+        return await this.checkErrorAndGetBody(result);
+    }
+
+    /**
+     * Deletes the database associated with this client
+     */
+    public async deleteDb(url: string = this.databaseUrl): Promise<BasicCouchResponse> {
+        const result = await this.axios.delete(url);
+        return await this.checkErrorAndGetBody(result);
+    }
+
     private encodeOptions(options: ListOptions) : object {
         let keys = Object.getOwnPropertyNames(options || {}) as (keyof ListOptions)[];
 
@@ -412,7 +428,7 @@ export class Client<T extends CouchDoc> {
                 case "start_key":
                 case "end_key":
                     requestOptions[key] = JSON.stringify(options[key]);
-                
+
                     break;
 
                 default:
@@ -511,8 +527,11 @@ export interface AllDocsListResult<T> {
     total_rows: number
 }
 
-interface CouchResponse {
+export interface BasicCouchResponse {
     ok: boolean;
+}
+
+interface CouchResponse extends BasicCouchResponse {
     id: string;
     rev: string;
 }
@@ -580,7 +599,7 @@ export interface PropSelector {
      * Property is not equal to this value.
      */
     $ne?: any;
-    
+
     /**
      * Property is greater than this value.
      */

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,4 +1,5 @@
 import Client, {
+    BasicCouchResponse,
     ClientOptions,
     configureDatabase,
     CouchDoc,
@@ -8,6 +9,7 @@ import Client, {
     } from '../';
 import inspect from 'logspect';
 import {
+    AsyncTeardownFixture,
     AsyncTest,
     Expect,
     TestFixture,
@@ -60,6 +62,26 @@ const designDoc: DesignDocConfiguration = {
 
 @TestFixture("Davenport")
 export class DavenportTestFixture {
+    @AsyncTest("Davenport.createDeleteDb")
+    @Timeout(5000)
+    public async createDeleteDbTest() {
+        const client = new Client(DB_URL, "davenport_delete_me", OPTIONS);
+
+        let result = await client.createDb();
+        Expect(result.ok).toBe(true);
+
+        result = await client.deleteDb();
+        Expect(result.ok).toBe(true);
+    }
+
+    @AsyncTeardownFixture
+    @Timeout(5000)
+    public async teardownFixture() {
+        const client = getClient();
+        const result = await client.deleteDb();
+        Expect(result.ok).toBe(true);
+    }
+
     @AsyncTest("Davenport.configureDatabase")
     @Timeout(5000)
     public async configureTest() {
@@ -354,7 +376,7 @@ export class DavenportTestFixture {
         });
 
         const sum = result.rows.reduce((sum, row) => sum + row.value, 0);
-        
+
         Expect(Array.isArray(result.rows)).toBe(true);
         Expect(sum).toBeGreaterThan(0);
     }
@@ -363,7 +385,7 @@ export class DavenportTestFixture {
     @Timeout(5000)
     public async viewWithKeysTest() {
         await this.createFoosGreaterThan10();
-        
+
         const client = getClient();
         const result = await client.view<TestObject>(designDoc.name, "by-foo-value", {
             start_key: 15,
@@ -401,7 +423,7 @@ export class DavenportTestFixture {
             };
 
             if (typeof(row.id) !== "string") {
-                pushError("row.id", "string");  
+                pushError("row.id", "string");
             }
 
             if (! row.key) {


### PR DESCRIPTION
This commit adds the createDb and deleteDb methods as well as
a unit test for them. In addition, it adds fixture teardown code
to delete the test database after all tests have run successfully.