### PR TITLE
Add zizmor security analysis workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Needed when cloning private repos.
+      actions: read          # Needed in private repos for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: true  # Enable SARIF upload; Davenport is public and has Advanced Security available


### PR DESCRIPTION
Added a Github Actions security workflow using zizmor, which scans workflow files for issues and uploads the findings to Github's Advanced Security feature (available for free on public repositories).

This will be used once branch 3.0.0-rc merges, which contains new Github workflows for building, testing and publishing Davenport.