### PR TITLE
 Update and streamline the release workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Setup justfile
-        uses: taiki-e/install-action@59012be0884e296ca2da49b530610e72c49039ad # v2.81.6
+        uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
         with:
           tool: just@1.51.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Setup justfile
-        uses: taiki-e/install-action@59012be0884e296ca2da49b530610e72c49039ad # v2.81.6
+        uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
         with:
           tool: just@1.51.0
 
@@ -46,7 +46,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 26
-          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # never cache in release builds
 
       - name: Install dependencies
         run: npm ci
@@ -59,21 +60,19 @@ jobs:
       - name: Build
         run: just build
 
-      - name: Commit package version change
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
-        with:
-          add: 'package.json package-lock.json'
-          commit: --signoff
-          message: 'Bump version to ${{ inputs.package_version }}'
-          pathspec_error_handling: exitAtEnd
-          default_author: github_actions
-          author_name: 'Dijon Bot'
-          author_email: '${{ vars.DIJON_BOT_USER_ID }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          push: true
-          github_token: ${{ steps.app-token.outputs.token }}
-
       - name: Test
         run: just test
+
+      - name: Commit and push version bump (signed)
+        id: bump
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: 'Bump version to ${{ inputs.package_version }}'
+          repo: ${{ github.repository }}
+          branch: ${{ github.ref_name }}
+          file_pattern: 'package.json package-lock.json'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Publish to NPM
         run: just publish-to-npm
@@ -82,14 +81,16 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: davenport
-          subject-path: 'index.ts' # This should ideally point to the dist folder or the root index.ts if we don't pack manually
+          subject-path: 'dist/**/*'
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PACKAGE_VERSION: ${{ inputs.package_version }}
+          COMMIT_SHA: ${{ steps.bump.outputs.commit-hash }}
         run: |
           gh release create "v${PACKAGE_VERSION}" \
+            --target "${COMMIT_SHA}" \
             --title "v${PACKAGE_VERSION}" \
             --generate-notes \
             --draft

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,37 @@
-index.ts
-bin/tests/
-node_modules/
-tsconfig.json
+# Source control
+.git/
+.jj/
+.github/
+.gitignore
+.jjignore
+
+# Build / dev tooling
+justfile
+tsconfig*.json
+vite.config.*
+vitest.config.*
+eslint.config.*
+.prettierrc*
+.prettierignore
+.editorconfig
+.npmrc
+
+# Tests
+tests/
+__tests__/
+**/*.test.ts
+**/*.test.js
+**/*.spec.ts
+**/*.spec.js
+
+# Build outputs / caches
+coverage/
 *.tgz
 *.log
+
+# Editor / OS
+.vscode/
+.idea/
+.claude/
+.DS_Store
+Thumbs.db

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",
-    "format": "prettier --write .",
-    "prepublishOnly": "npm run build"
+    "format": "prettier --write ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Several small adjustments in these commits which streamline the release workflow:

1. The workflow was previously running tests, building, bumping the version, **pushing to main**, running tests again, building again, then pushing to NPM. While it's unlikely anything would've actually broken from a version bump, it still introduced the possibility of bumping the version, pushing it back to the repo, then failing to to publish the version bump to NPM. The order has been adjusted so that the workflow now builds, runs tests, bumps and commits then publishes.

2. The commit action itself was changed to use `planetscale/ghcommit-action`, which signs the commits using Github's web signing key.

3. The step that creates the new Github release now specifically creates uses the commit id that was created for the version bump, rather than whatever commit happens to be in `main` at the time (preventing a potential, admittedly rare, race condition).

4. Fixed the provenance action to point at the ./dist folder (it was previously pointing at the ./index.ts file, which no longer exists).

5. Dropped the `prepublishOnly` script since the package is built explicitly by the workflow, making the script redundant.

6. Updated the patters in .npmignore to reflect the current package, now that it's been modernized and migrated off of Webpack over to Vite.