### PR TITLE
Fix Typescript declaration file generation in build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,7 +8,7 @@ on:
       - 'README.md'
       - 'justfile'
   pull_request:
-    branches: ["**"]
+    branches: ['**']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,9 +2,9 @@ name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
-    branches: ["main"]
+    branches: ['main']
   pull_request:
-    branches: ["**"]
+    branches: ['**']
 
 permissions: {}
 
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      contents: read         # Needed when cloning private repos.
-      actions: read          # Needed in private repos for upload-sarif to read workflow run info.
+      contents: read # Needed when cloning private repos.
+      actions: read # Needed in private repos for upload-sarif to read workflow run info.
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -25,4 +25,4 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
-          advanced-security: true  # Enable SARIF upload; Davenport is public and has Advanced Security available
+          advanced-security: true # Enable SARIF upload; Davenport is public and has Advanced Security available

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "experimentalDecorators": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["index.ts", "tests/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
+import { copyFileSync } from 'fs';
 
 export default defineConfig({
   build: {
@@ -11,7 +12,18 @@ export default defineConfig({
       formats: ['es'],
     },
   },
-  plugins: [dts({ rollupTypes: true })],
+  plugins: [
+    dts({ entryRoot: 'src' }),
+    {
+      name: 'copy-types',
+      closeBundle() {
+        copyFileSync(
+          resolve(__dirname, 'src/types.d.ts'),
+          resolve(__dirname, 'dist/types.d.ts')
+        );
+      },
+    },
+  ],
   test: {
     globals: true,
     environment: 'node',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,10 +17,7 @@ export default defineConfig({
     {
       name: 'copy-types',
       closeBundle() {
-        copyFileSync(
-          resolve(__dirname, 'src/types.d.ts'),
-          resolve(__dirname, 'dist/types.d.ts')
-        );
+        copyFileSync(resolve(__dirname, 'src/types.d.ts'), resolve(__dirname, 'dist/types.d.ts'));
       },
     },
   ],


### PR DESCRIPTION
The build was producing an empty index.d.ts file due to misconfigured A) Typescript include paths, and B) misconfigured vite-plugin-dts settings. This fix uppdate the tsconfig.json file to include `src/**/*.ts` instead of the obsolete `index.ts` file, and configures the dts plugin to set the entry root to `./src`. Finally, I had to add a custom plugin to copy the types.d.ts file to the dist directory, as neither Vite nor the dts plugin does this automatically (which seems odd).