### PR TITLE
Also publish to the Github Packages registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,14 @@ on:
         description: 'New package version (required unless skipping version bump)'
         type: string
         required: false
+      platform:
+        description: 'Platform(s) to publish to'
+        type: choice
+        options:
+          - both
+          - npm
+          - github
+        default: 'both'
         required: true
       skip_version_bump:
         description: 'Skip bumping the version and skip creating a GitHub release (uses version already in package.json)'
@@ -25,6 +33,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      packages: write
 
     steps:
       - name: Setup justfile
@@ -72,6 +81,20 @@ jobs:
       - name: Build
         run: just build
 
+      - name: Commit package version change
+        if: ${{ !inputs.skip_version_bump }}
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
+        with:
+          add: 'package.json package-lock.json'
+          commit: --signoff
+          message: 'Bump version to ${{ inputs.package_version }}'
+          pathspec_error_handling: exitAtEnd
+          default_author: github_actions
+          author_name: 'Dijon Bot'
+          author_email: '${{ vars.DIJON_BOT_USER_ID }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          push: true
+          github_token: ${{ steps.app-token.outputs.token }}
+
       - name: Test
         run: just test
 
@@ -87,8 +110,24 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Publish to NPM
-        run: just publish-to-npm
         if: ${{ inputs.platform == 'both' || inputs.platform == 'npm' }}
+        run: just publish-package npm
+
+      # Reconfigures .npmrc with auth for the GitHub Packages registry so that
+      # NODE_AUTH_TOKEN is picked up when publishing in the next step.
+      - name: Setup Node.js for GitHub Packages
+        if: ${{ inputs.platform == 'both' || inputs.platform == 'github' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 26
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@nozzlegear'
+
+      - name: Publish to GitHub Packages
+        if: ${{ inputs.platform == 'both' || inputs.platform == 'github' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: just publish-package github
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,18 @@
 name: Release Pipeline
-run-name: Publish ${{ inputs.package_version }}
+run-name: Publish ${{ inputs.skip_version_bump && '(current version)' || inputs.package_version }}
 
 on:
   workflow_dispatch:
     inputs:
       package_version:
-        description: 'New package version'
+        description: 'New package version (required unless skipping version bump)'
         type: string
+        required: false
         required: true
+      skip_version_bump:
+        description: 'Skip bumping the version and skip creating a GitHub release (uses version already in package.json)'
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -52,7 +57,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate inputs
+        if: ${{ !inputs.skip_version_bump && !inputs.package_version }}
+        run: |
+          echo "::error::package_version is required when skip_version_bump is false."
+          exit 1
+
       - name: Set package version
+        if: ${{ !inputs.skip_version_bump }}
         env:
           PACKAGE_VERSION: ${{ inputs.package_version }}
         run: just set-package-version "$PACKAGE_VERSION"
@@ -76,6 +88,7 @@ jobs:
 
       - name: Publish to NPM
         run: just publish-to-npm
+        if: ${{ inputs.platform == 'both' || inputs.platform == 'npm' }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -84,6 +97,7 @@ jobs:
           subject-path: 'dist/**/*'
 
       - name: Create GitHub release
+        if: ${{ !inputs.skip_version_bump }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PACKAGE_VERSION: ${{ inputs.package_version }}

--- a/justfile
+++ b/justfile
@@ -59,9 +59,16 @@ format:
 set-package-version version:
     npm version "{{version}}" --no-git-tag-version
 
-# Publish to NPM
+# Publish the package to NPM or Github
 [group("release")]
 [script]
-publish-to-npm:
-    npm stage publish
-
+[arg("platform", pattern="npm|github")]
+publish-package platform:
+    if [ "{{platform}}" = "github" ]; then
+        npm pkg set name="@nozzlegear/davenport"
+        # Github does not support provenance or staged publishing at this time
+        npm publish --registry https://npm.pkg.github.com --no-provenance
+    else
+        npm pkg set name="davenport"
+        npm stage publish
+    fi


### PR DESCRIPTION
This is a small change to the release.yaml workflow, adding the Github Packages registry as a publish target. Also includes the ability to choose the publish target (NPM, Github or both) and the ability to skip the version bump + Github release (as in, the release created on the repository – separate from the Github Packages publish).